### PR TITLE
Fixing issue with IMSHOW dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ r2p2/__pycache__/neurocontroller.cpython-37.pyc
 r2p2/__pycache__/thetaStar.cpython-37.pyc
 r2p2/ga.py
 r2p2/thetaStar.py
+*.pyc

--- a/r2p2/utils.py
+++ b/r2p2/utils.py
@@ -35,7 +35,7 @@ from PIL import Image, ImageDraw, ImageColor
 import numpy as np
 import pygame
 from scipy import ndimage as filters
-from scipy.misc import imshow
+from matplotlib.pyplot import imshow
 from scipy.stats import norm
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation


### PR DESCRIPTION
It seems imshow was included in scipy until certain version as this module is part of matplotlib package which was already included in the requirements, just started to use it directly form matplotlib.

Documentation related to the depreaction warning: https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.misc.imshow.html