### PR TITLE
Decorator to simplify the implementation of control methods on Controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ r2p2/__pycache__/neurocontroller.cpython-37.pyc
 r2p2/__pycache__/thetaStar.cpython-37.pyc
 r2p2/ga.py
 r2p2/thetaStar.py
+*.pyc

--- a/conf/scenario-naive-test.json
+++ b/conf/scenario-naive-test.json
@@ -1,0 +1,6 @@
+{
+	"stage": "../res/stage.png",
+	"robot": ["../conf/robot.json"],
+	"controller": "../conf/controller-naive.json",
+	"gui": true
+}

--- a/r2p2/controller.py
+++ b/r2p2/controller.py
@@ -128,3 +128,10 @@ class Controller(ABC):
 
     def set_ang(self, ang):
         self.ang = ang
+
+def upd_sensor_angles(function):
+    """Decorator to simplify the implementation of "control" methods on Controller subclasses"""
+    def wrapper(self, dst):
+        self.update_sensor_angles(self.ang, dst)
+        return function(self, dst)
+    return wrapper

--- a/r2p2/controllers/naive_controller.py
+++ b/r2p2/controllers/naive_controller.py
@@ -30,9 +30,9 @@ __status__ = "Development"
 __version__ = "0.0.1"
 
 
-import controller
+from controller import Controller, upd_sensor_angles
 
-class Naive_Controller(controller.Controller):
+class Naive_Controller(Controller):
     """
         Class implementing an extremely simple naive controller.
         Not really dependable, meant to serve as a simple example
@@ -46,6 +46,7 @@ class Naive_Controller(controller.Controller):
         """
         super().__init__("NAIVE")
 
+    @upd_sensor_angles
     def control(self, dst):
         """
             Driver function to centralize and standardize the controller. Can be modified by child classes,


### PR DESCRIPTION
As we had a bug because the NaiveController was not calling to the Controller.control() and I see that most of the controller implementations we have starts with the following line:
self.update_sensor_angles(self.ang, dst)

I have created a decorator to simplify it. So if we need to add that line to most of our control methods, we just need to add the decorator. If at some point we need to do more steps to update the sensor angles, we could add it to the decorator so all "control" methods implements it in the same way.

If this is overcomplicate the issue, I'll prepare other PR just calling the super() implementation.