### PR TITLE
Removing the version forced of scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ matplotlib
 seaborn>=0.9
 scikit-learn
 Pillow
-scipy==1.1.0
+scipy
 inspyred
 pygame


### PR DESCRIPTION
As mentioned by David, it was forcing a version of scipy that is obsolete. In python 3.7 it was working correctly, but I had problems to install it using 3.8 or higher and in the best case it kept showing some warnings.