### PR TITLE
Develop

### DIFF
--- a/r2p2/config_manager/config_manager.py
+++ b/r2p2/config_manager/config_manager.py
@@ -1,8 +1,10 @@
 import json
 
 class ConfigManager():
-  def __init__(self, scenario_config = '../conf/scenario-default.json', controller_config = None):
+  def __init__(self, scenario_config = '../conf/scenario-default.json', controller_config = None, params = None):
     self.config = self.__get_json(scenario_config)
+    self.override_with_cli_params(params)
+    print(self.config)
 
     if controller_config:
       print("Using controller from Command Line args")
@@ -11,7 +13,10 @@ class ConfigManager():
       self.__load_controller_conf()
     # Override controllers' params if they are found in the scenario too
     self.__override_with_scen()
-    
+
+  def override_with_cli_params(self, params):
+    self.config = {**self.config, **params}
+
   def get_config(self):
     return self.config
   

--- a/r2p2/controllers/pid_controller.py
+++ b/r2p2/controllers/pid_controller.py
@@ -266,7 +266,6 @@ class Sequential_PID_Controller(Controller):
         initial_point = self.goal[0]
         self.robot.set_position(initial_point[0], initial_point[1])
         self.robot.set_last_position(initial_point[0], initial_point[1])
-        print(self.robot.last_pos)
         
 def path_planning_controller(config):
     """

--- a/r2p2/r2p2.py
+++ b/r2p2/r2p2.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(\
         description='Run a simulation using a specified scenario.',
-        epilog='Any extra argument passed through the CLI will be used to overwrite scenario parameters. Do not enter spaces in the values! Ex: --start [20,10] --test -5.2')
+        epilog='Any extra argument passed through the CLI will be used to overwrite scenario parameters. Do not enter spaces in the values or add quotes! Ex: --start [20,10] --goal "[21, 11]"')
     parser.add_argument('--version', action='store_true', \
             help='Displays the current version of the simulator.')
     parser.add_argument('--scenario', metavar='S', nargs='?',\

--- a/r2p2/r2p2.py
+++ b/r2p2/r2p2.py
@@ -29,6 +29,7 @@ __maintainer__ = "Mario Cobos Maestre"
 __status__ = "Development"
 __version__ = "1.0.0b"
 
+import json
 import utils as u
 
 from config_manager import ConfigManager
@@ -42,26 +43,40 @@ def start_simulation(config='../conf/scenario-default.json'):
     """
     u.load_simulation(config)
 
+def args_list_to_dict(args: list):
+    dictionary = {}
+    for x in range(int(len(args)/2)):
+        key_pos = x*2
+        val_pos = x*2+1
+
+        # Removing hiphens on the left
+        key = args[key_pos].lstrip('-')
+        # Casting the value as json to accept plain parameters, lists, objects, nested objects...
+        val = json.loads(args[val_pos])
+        dictionary[key] = val
+    return dictionary
+
 if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(\
-        description='Run a simulation using a specified scenario.')
+        description='Run a simulation using a specified scenario.',
+        epilog='Any extra argument passed through the CLI will be used to overwrite scenario parameters. Do not enter spaces in the values! Ex: --start [20,10] --test -5.2')
     parser.add_argument('--version', action='store_true', \
             help='Displays the current version of the simulator.')
     parser.add_argument('--scenario', metavar='S', nargs='?',\
         help='Path to the configuration JSON in which the scenario is defined.')
     parser.add_argument('--controller', metavar='C', nargs='?',\
         help='Path to the controller that you want to use. This will override the scenario one if there was any.')
-    args = parser.parse_args()
-    
+    args, unknown = parser.parse_known_args()
+    unknown_args = args_list_to_dict(unknown)
 
     if args.version:
         print('R2P2 v.'+__version__)
         exit()
     
     if args.scenario:
-        config_mgr = ConfigManager(scenario_config = args.scenario, controller_config = args.controller)
+        config_mgr = ConfigManager(scenario_config = args.scenario, controller_config = args.controller, params = unknown_args)
     else:
-        config_mgr = ConfigManager(controller_config = args.controller)
+        config_mgr = ConfigManager(controller_config = args.controller, params = unknown_args)
     start_simulation(config_mgr)


### PR DESCRIPTION
Adding the possibility to override parameters of the scenario using the cli commands.

For example:
r2p2.py --scenario test.py --start [10,20] --goal "[11, 21]"

Should be able to cast anything allowed in JSON, so it should have no issues with plain values (int, float, negative numbers, strings, booleans...), lists of basic types and theoretically (didn't tested it) should accept objects, nested objects casted as dictionaries I guess...